### PR TITLE
fix: update revision type

### DIFF
--- a/src/wallet-api/typedData.ts
+++ b/src/wallet-api/typedData.ts
@@ -37,7 +37,7 @@ export interface StarknetDomain extends Record<string, unknown> {
   name?: string;
   version?: string;
   chainId?: string | number; // TODO: check resolution, diverge from SPEC and follow SNIP-12
-  revision?: string;
+  revision?: string | number; // TODO: future versions 1+ should be only string. The type should be kept as shortstring, but the value should be passed as 1 instead of ‘1’, Just for revision 1
 }
 
 /**


### PR DESCRIPTION
future versions 1+ should be only string. The type should be kept as shortstring, but the value should be passed as 1 instead of ‘1’, Just for revision 1