### PR TITLE
Remove [] from wallet_getPermissions result type

### DIFF
--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -29,7 +29,7 @@ export interface RpcTypeToMessageMap {
    */
   wallet_getPermissions: {
     params?: ApiVersionRequest;
-    result: Permission[] | [];
+    result: Permission[];
     errors: Errors.API_VERSION_NOT_SUPPORTED | Errors.UNKNOWN_ERROR;
   };
 


### PR DESCRIPTION
The `[]` is just not needed to be there, and it also messes up the type.