### PR TITLE
fix: add snip-29 implementation for RPC 0.8

### DIFF
--- a/src/api/components.ts
+++ b/src/api/components.ts
@@ -47,6 +47,9 @@ export type ETH_ADDRESS = string;
  * @pattern ^0x(0|[0-7]{1}[a-fA-F0-9]{0,62}$)
  */
 export type STORAGE_KEY = string;
+/**
+ * A contract address on Starknet
+ */
 export type ADDRESS = FELT;
 /**
  * string representing an integer number in prefixed hexadecimal format

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export * as API from './api/index.js';
 
 export * from './wallet-api/index.js';
 export * as WALLET_API from './wallet-api/index.js';
+
+export * as PAYMASTER_API from './snip-29/index.js';

--- a/src/snip-29/components.ts
+++ b/src/snip-29/components.ts
@@ -1,0 +1,212 @@
+import { ADDRESS, FELT, SIGNATURE, TXN_HASH } from '../api/components';
+
+//    ******************
+//    * PRIMITIVES
+//    ******************
+
+/**
+ * 256 bit unsigned integers, represented by a hex string of length at most 64
+ * @pattern ^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,63})$
+ */
+export type u256 = string;
+/**
+ * A string representing an unsigned integer
+ * @pattern ^(0|[1-9]{1}[0-9]*)$
+ */
+export type NUMERIC = string;
+/**
+ * UNIX time
+ */
+export type TIMESTAMP = NUMERIC;
+/**
+ * The object that defines an invocation of a function in a contract
+ */
+export type CALL = {
+  to: ADDRESS;
+  selector: FELT;
+  calldata: FELT[];
+};
+/**
+ * The transaction hash
+ */
+export type TRANSACTION_HASH = TXN_HASH;
+/**
+ * A unique identifier corresponding to an `execute` request to the paymaster
+ */
+export type TRACKING_ID = FELT;
+/**
+ * "A typed data object (in the sense of SNIP-12) which represents an outside execution payload, according to SNIP-9
+ */
+export type OUTSIDE_EXECUTION_TYPED_DATA =
+  | OUTSIDE_EXECUTION_TYPED_DATA_V1
+  | OUTSIDE_EXECUTION_TYPED_DATA_V2;
+export type OUTSIDE_EXECUTION_TYPED_DATA_V1 = {
+  types: Record<string, STARKNET_TYPE[]>;
+  primaryType: string;
+  domain: STARKNET_DOMAIN;
+  message: OUTSIDE_EXECUTION_MESSAGE_V1;
+};
+export type OUTSIDE_EXECUTION_TYPED_DATA_V2 = {
+  types: Record<string, STARKNET_TYPE[]>;
+  primaryType: string;
+  domain: STARKNET_DOMAIN;
+  message: OUTSIDE_EXECUTION_MESSAGE_V2;
+};
+/**
+ * A single type, as part of a struct. The `type` field can be any of the EIP-712 supported types
+ */
+export type STARKNET_TYPE =
+  | {
+      name: string;
+      type: string;
+    }
+  | STARKNET_ENUM_TYPE
+  | STARKNET_MERKLE_TYPE;
+export type STARKNET_ENUM_TYPE = {
+  name: string;
+  type: 'enum';
+  contains: string;
+};
+export type STARKNET_MERKLE_TYPE = {
+  name: string;
+  type: 'merkletree';
+  contains: string;
+};
+/**
+ * A single type, as part of a struct. The `type` field can be any of the EIP-712 supported types
+ */
+export type STARKNET_DOMAIN = {
+  name?: string;
+  version?: string;
+  chainId?: string | number;
+  revision?: string | number;
+};
+export type OUTSIDE_EXECUTION_MESSAGE_V1 = {
+  caller: FELT;
+  nonce: FELT;
+  execute_after: FELT;
+  execute_before: FELT;
+  calls_len: FELT;
+  calls: OUTSIDE_CALL_V1[];
+};
+export type OUTSIDE_CALL_V1 = {
+  to: ADDRESS;
+  selector: FELT;
+  calldata_len: FELT[];
+  calldata: FELT[];
+};
+export type OUTSIDE_EXECUTION_MESSAGE_V2 = {
+  Caller: FELT;
+  Nonce: FELT;
+  'Execute After': FELT;
+  'Execute Before': FELT;
+  Calls: OUTSIDE_CALL_V2[];
+};
+export type OUTSIDE_CALL_V2 = {
+  To: ADDRESS;
+  Selector: FELT;
+  Calldata: FELT[];
+};
+
+/**
+ * User transaction
+ */
+export type USER_DEPLOY_TRANSACTION = {
+  type: 'deploy';
+  deployment: ACCOUNT_DEPLOYMENT_DATA;
+};
+export type USER_INVOKE_TRANSACTION = {
+  type: 'invoke';
+  invoke: USER_INVOKE;
+};
+export type USER_INVOKE = {
+  user_address: ADDRESS;
+  calls: CALL[];
+};
+export type USER_DEPLOY_AND_INVOKE_TRANSACTION = {
+  type: 'deploy_and_invoke';
+  deployment: ACCOUNT_DEPLOYMENT_DATA;
+  invoke: USER_INVOKE;
+};
+export type USER_TRANSACTION =
+  | USER_DEPLOY_TRANSACTION
+  | USER_INVOKE_TRANSACTION
+  | USER_DEPLOY_AND_INVOKE_TRANSACTION;
+
+/**
+ * User transaction
+ */
+export type EXECUTABLE_USER_DEPLOY_TRANSACTION = {
+  type: 'deploy';
+  deployment: ACCOUNT_DEPLOYMENT_DATA;
+};
+export type EXECUTABLE_USER_INVOKE_TRANSACTION = {
+  type: 'invoke';
+  invoke: EXECUTABLE_USER_INVOKE;
+};
+export type EXECUTABLE_USER_INVOKE = {
+  user_address: ADDRESS;
+  typed_data: OUTSIDE_EXECUTION_TYPED_DATA;
+  signature: SIGNATURE;
+};
+export type EXECUTABLE_USER_DEPLOY_AND_INVOKE_TRANSACTION = {
+  type: 'deploy_and_invoke';
+  deployment: ACCOUNT_DEPLOYMENT_DATA;
+  invoke: EXECUTABLE_USER_INVOKE;
+};
+export type EXECUTABLE_USER_TRANSACTION =
+  | EXECUTABLE_USER_DEPLOY_TRANSACTION
+  | EXECUTABLE_USER_INVOKE_TRANSACTION
+  | EXECUTABLE_USER_DEPLOY_AND_INVOKE_TRANSACTION;
+
+/**
+ * Execution parameters
+ */
+export type SPONSORED_TRANSACTION = {
+  mode: 'sponsored';
+};
+export type GASLESS_TRANSACTION = {
+  mode: 'default';
+  gas_token: FELT;
+};
+export type FEE_MODE = SPONSORED_TRANSACTION | GASLESS_TRANSACTION;
+export type EXECUTION_PARAMETERS_V1 = {
+  version: '0x1';
+  fee_mode: FEE_MODE;
+  time_bounds?: TIME_BOUNDS;
+};
+export type EXECUTION_PARAMETERS = EXECUTION_PARAMETERS_V1;
+/**
+ * Data required to deploy an account at an address
+ */
+export type ACCOUNT_DEPLOYMENT_DATA = {
+  address: ADDRESS;
+  class_hash: FELT;
+  salt: FELT;
+  calldata: FELT[];
+  sigdata?: FELT[];
+  version: 1;
+};
+/**
+ * Object containing timestamps corresponding to `Execute After` and `Execute Before`
+ */
+export type TIME_BOUNDS = {
+  execute_after: TIMESTAMP;
+  execute_before: TIMESTAMP;
+};
+/**
+ * Object containing data about the token: contract address, number of decimals and current price in STRK
+ */
+export type TOKEN_DATA = {
+  address: ADDRESS;
+  decimals: number;
+  price_in_strk: u256;
+};
+
+export type FEE_ESTIMATE = {
+  gas_token_price_in_strk: FELT;
+  estimated_fee_in_strk: FELT;
+  estimated_fee_in_gas_token: FELT;
+  suggested_max_fee_in_strk: FELT;
+  suggested_max_fee_in_gas_token: FELT;
+};

--- a/src/snip-29/errors.ts
+++ b/src/snip-29/errors.ts
@@ -1,0 +1,48 @@
+import { CONTRACT_EXECUTION_ERROR } from '../api/components';
+
+export interface INVALID_ADDRESS {
+  code: 150;
+  message: 'An error occurred (INVALID_ADDRESS)';
+}
+export interface TOKEN_NOT_SUPPORTED {
+  code: 151;
+  message: 'An error occurred (TOKEN_NOT_SUPPORTED)';
+}
+export interface INVALID_SIGNATURE {
+  code: 153;
+  message: 'An error occurred (INVALID_SIGNATURE)';
+}
+export interface MAX_AMOUNT_TOO_LOW {
+  code: 154;
+  message: 'An error occurred (MAX_AMOUNT_TOO_LOW)';
+}
+export interface CLASS_HASH_NOT_SUPPORTED {
+  code: 155;
+  message: 'An error occurred (CLASS_HASH_NOT_SUPPORTED)';
+}
+export interface TRANSACTION_EXECUTION_ERROR {
+  code: 156;
+  message: 'An error occurred (TRANSACTION_EXECUTION_ERROR)';
+  data: CONTRACT_EXECUTION_ERROR;
+}
+export interface INVALID_TIME_BOUNDS {
+  code: 157;
+  message: 'An error occurred (INVALID_TIME_BOUNDS)';
+}
+export interface INVALID_DEPLOYMENT_DATA {
+  code: 158;
+  message: 'An error occurred (INVALID_DEPLOYMENT_DATA)';
+}
+export interface INVALID_CLASS_HASH {
+  code: 159;
+  message: 'An error occurred (INVALID_CLASS_HASH)';
+}
+export interface INVALID_ID {
+  code: 160;
+  message: 'An error occurred (INVALID_ID)';
+}
+export interface UNKNOWN_ERROR {
+  code: 163;
+  message: 'An error occurred (UNKNOWN_ERROR)';
+  data: string;
+}

--- a/src/snip-29/index.ts
+++ b/src/snip-29/index.ts
@@ -1,0 +1,4 @@
+export * from './methods.js';
+export * from './errors.js';
+export * from './components.js';
+export * from './nonspec.js';

--- a/src/snip-29/methods.ts
+++ b/src/snip-29/methods.ts
@@ -1,0 +1,60 @@
+import {
+  USER_TRANSACTION,
+  TOKEN_DATA,
+  EXECUTION_PARAMETERS,
+  EXECUTABLE_USER_TRANSACTION,
+} from './components';
+import * as Errors from './errors';
+import { BuildTransactionResponse, ExecuteResponse } from './nonspec';
+
+type ReadMethods = {
+  // Returns the status of the paymaster service
+  paymaster_isAvailable: {
+    params: [];
+    result: boolean;
+  };
+
+  // Receives the transaction the user wants to execute. Returns the typed data along with the estimated gas cost and the maximum gas cost suggested to ensure execution
+  paymaster_buildTransaction: {
+    params: {
+      transaction: USER_TRANSACTION;
+      parameters: EXECUTION_PARAMETERS;
+    };
+    result: BuildTransactionResponse;
+    errors:
+      | Errors.INVALID_ADDRESS
+      | Errors.CLASS_HASH_NOT_SUPPORTED
+      | Errors.INVALID_DEPLOYMENT_DATA
+      | Errors.TOKEN_NOT_SUPPORTED
+      | Errors.INVALID_TIME_BOUNDS
+      | Errors.UNKNOWN_ERROR
+      | Errors.TRANSACTION_EXECUTION_ERROR;
+  };
+
+  // Get a list of the tokens that the paymaster supports, together with their prices in STRK
+  paymaster_getSupportedTokens: {
+    params: {};
+    result: TOKEN_DATA[];
+  };
+};
+
+type WriteMethods = {
+  // Sends the signed typed data to the paymaster service for execution
+  paymaster_executeTransaction: {
+    params: {
+      transaction: EXECUTABLE_USER_TRANSACTION;
+      parameters: EXECUTION_PARAMETERS;
+    };
+    result: ExecuteResponse;
+    errors:
+      | Errors.INVALID_ADDRESS
+      | Errors.CLASS_HASH_NOT_SUPPORTED
+      | Errors.INVALID_DEPLOYMENT_DATA
+      | Errors.INVALID_SIGNATURE
+      | Errors.UNKNOWN_ERROR
+      | Errors.MAX_AMOUNT_TOO_LOW
+      | Errors.TRANSACTION_EXECUTION_ERROR;
+  };
+};
+
+export type Methods = ReadMethods & WriteMethods;

--- a/src/snip-29/nonspec.ts
+++ b/src/snip-29/nonspec.ts
@@ -1,0 +1,46 @@
+/**
+ * Types that are not in spec but required for UX
+ */
+import {
+  ACCOUNT_DEPLOYMENT_DATA,
+  EXECUTION_PARAMETERS,
+  FEE_ESTIMATE,
+  OUTSIDE_EXECUTION_TYPED_DATA,
+  TRACKING_ID,
+  TRANSACTION_HASH,
+} from './components';
+
+// METHOD RESPONSES
+// response paymaster_buildTransaction
+export type BuildDeployTransactionResponse = {
+  type: 'deploy';
+  deployment: ACCOUNT_DEPLOYMENT_DATA;
+  parameters: EXECUTION_PARAMETERS;
+  fee: FEE_ESTIMATE;
+};
+export type BuildInvokeTransactionResponse = {
+  type: 'invoke';
+  typed_data: OUTSIDE_EXECUTION_TYPED_DATA;
+  parameters: EXECUTION_PARAMETERS;
+  fee: FEE_ESTIMATE;
+};
+export type BuildDeployAndInvokeTransactionResponse = {
+  type: 'deploy_and_invoke';
+  deployment: ACCOUNT_DEPLOYMENT_DATA;
+  typed_data: OUTSIDE_EXECUTION_TYPED_DATA;
+  parameters: EXECUTION_PARAMETERS;
+  fee: FEE_ESTIMATE;
+};
+export type BuildTransactionResponse =
+  | BuildDeployTransactionResponse
+  | BuildInvokeTransactionResponse
+  | BuildDeployAndInvokeTransactionResponse;
+
+// response paymaster_execute
+export type ExecuteResponse = {
+  tracking_id: TRACKING_ID;
+  transaction_hash: TRANSACTION_HASH;
+};
+
+export type AccountDeploymentData = ACCOUNT_DEPLOYMENT_DATA;
+export type OutsideExecutionTypedData = OUTSIDE_EXECUTION_TYPED_DATA;


### PR DESCRIPTION
Add implementation of the types for the snip-29 based on PR https://github.com/starknet-io/starknet.js/pull/1377 from @florian-bellotti, with integration simplifications.