### PR TITLE
fix: implements spec v 0.10.3-rc1

### DIFF
--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -192,7 +192,8 @@ export type STRK20_WITHDRAW_ACTION = {
 export type STRK20_TRANSFER_ACTION = {
   type: 'transfer'
   token: ADDRESS
-  amount: FELT
+  /** FELT amount, or "OPEN" to transfer the full opened note balance */
+  amount: FELT | 'OPEN'
   recipient: ADDRESS
 }
 


### PR DESCRIPTION
## Rpc 0.10.3 rc1

Implements the single breaking change introduced in spec [v0.10.3-rc.1](https://github.com/starkware-libs/starknet-specs/compare/v0.10.3-rc.0...v0.10.3-rc.1).

### Change

`STRK20_TRANSFER_ACTION.amount` (`src/wallet-api/components.ts`) is widened from `FELT` to `FELT | 'OPEN'`.  
Passing `"OPEN"` instructs the wallet to transfer the entire balance of the opened note without the caller needing to know the exact amount.
