### PR TITLE
fix: implements spec v0.10.3-rc2

### DIFF
--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -228,6 +228,7 @@ export interface RpcTypeToMessageMap {
    */
   wallet_strk20Balances: {
     params: {
+      /** Token addresses to query. Pass an empty array to return balances of all shielded tokens in the privacy pool. */
       tokens: Address[]
       api_version?: API_VERSION
     }


### PR DESCRIPTION
## Summary

Implements Starknet spec `v0.10.3-rc.2`.

The only functional change vs rc.1 is in `wallet_strk20Balances`: the `tokens` parameter no longer requires at least one entry — an empty array is now valid and returns the balances of **all shielded tokens** held in the privacy pool.

The TypeScript type (`Address[]`) was already correct; this PR adds a JSDoc comment on `tokens` to document the empty-array semantics.

## Spec reference

- [v0.10.3-rc.2](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.3-rc.2)
- Changed file: `wallet-api/wallet_rpc.json` — removed `minItems: 1` from `wallet_strk20Balances.params.tokens`
