### PR TITLE
fix: implement spec v0.10.3-rc.3

### DIFF
--- a/src/proving-api/components.ts
+++ b/src/proving-api/components.ts
@@ -7,4 +7,11 @@ export type PROVE_TRANSACTION_RESULT = {
   proof: PROOF
   proof_facts: PROOF_FACTS
   l2_to_l1_messages: MSG_TO_L1[]
+  /**
+   * Opaque side-channel attached alongside the proof and relayed verbatim by the prover
+   * from the external blocking check service. Optional; omitted from the response when absent.
+   * The prover does not interpret its contents — concrete keys (e.g. a screening signature
+   * under `signature`) are defined by the producing service, not by this API.
+   */
+  additional_data?: Record<string, unknown>
 }

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -20,10 +20,14 @@ export type PADDED_TXN_HASH = PADDED_FELT // TODO: Should be like TXN_HASH_PADDE
 export type PADDED_FELT = string // TODO: STORAGE_KEY should also be PADDED_FELT to remove duplication, and padded felt added to api spec ?
 
 /**
- * A Starknet RPC spec version, only two numbers are provided
- * @pattern ^[0-9]+\\.[0-9]+$
+ * A Starknet JSON-RPC spec version, following semantic versioning.
+ * @pattern ^[0-9]+\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z.-]+)?)?$
+ * @example "0.10" | "0.10.3" | "0.10.3-rc.3"
  */
-export type SpecVersion = string
+export type SpecVersion =
+  | `${number}.${number}`
+  | `${number}.${number}.${number}`
+  | `${number}.${number}.${number}-${string}`
 
 /**
  * ERC20 Token Symbol (min:1 char - max:6 chars)
@@ -147,7 +151,13 @@ export interface AccountDeploymentData {
   version: 0 | 1 // Cairo version (an integer)
 }
 
-export type API_VERSION = string
+/**
+ * A wallet API version, following semantic versioning (no pre-release).
+ * When used as a request parameter and not specified, the latest is assumed.
+ * @pattern ^[0-9]+\\.[0-9]+(\\.[0-9]+)?$
+ * @example "0.8" | "0.10.3"
+ */
+export type API_VERSION = `${number}.${number}` | `${number}.${number}.${number}`
 
 /**
  * The version of wallet API the request expecting. If not specified, the latest is assumed
@@ -185,9 +195,10 @@ export type STRK20_CALL_AND_PROOF = {
 
 /**
  * A wallet-resolved placeholder that the wallet substitutes with a single felt
- * during STRK20 action assembly. ${openNoteIds[N]} expands to the Nth note ID
- * created by openNote actions in the same transaction; ${poolAddress} expands to
- * the privacy pool contract address. N is a zero-based index.
+ * during STRK20 action assembly. ${openNoteIds[N]} expands to the ID of the Nth
+ * open note in the same transaction (i.e. the Nth transfer action with amount
+ * "OPEN"); ${poolAddress} expands to the privacy pool contract address. N is a
+ * zero-based index.
  * @pattern ^\$\{(?:openNoteIds\[[0-9]+\]|poolAddress)\}$
  */
 export type STRK20_CALLDATA_PLACEHOLDER = string
@@ -224,7 +235,7 @@ export type STRK20_WITHDRAW_ACTION = {
 export type STRK20_TRANSFER_ACTION = {
   type: 'transfer'
   token: ADDRESS
-  /** FELT amount, or "OPEN" to transfer the full opened note balance */
+  /** FELT amount in the token's smallest unit, or the literal "OPEN" to create a new open note */
   amount: FELT | 'OPEN'
   recipient: ADDRESS
 }
@@ -233,8 +244,8 @@ export type STRK20_TRANSFER_ACTION = {
  * Invokes an arbitrary contract entry point as part of the same STRK20
  * transaction. Calldata items may be literal felts or wallet-resolved
  * placeholders that the wallet substitutes during action assembly:
- * ${openNoteIds[N]} for the Nth opened note ID, or ${poolAddress} for the privacy
- * pool address.
+ * ${openNoteIds[N]} for the ID of the Nth open note (the Nth transfer action with
+ * amount "OPEN"), or ${poolAddress} for the privacy pool address.
  */
 export type STRK20_INVOKE_ACTION = {
   type: 'invoke'


### PR DESCRIPTION
## Implement Starknet spec v0.10.3-rc.3

Aligns the library with the `v0.10.3-rc.2 → rc.3` spec increment.

### Version format (semantic versioning)

The spec relaxed `SPEC_VERSION` / `API_VERSION` from a strict `X.Y` pattern to
semver. Both types go from plain `string` to template-literal unions, mirroring
the new patterns where the spec defines them (wallet-api only):

- `SpecVersion`: `X.Y | X.Y.Z | X.Y.Z-prerelease`
  (`@pattern ^[0-9]+\.[0-9]+(\.[0-9]+(-[0-9A-Za-z.-]+)?)?$`)
- `API_VERSION`: `X.Y | X.Y.Z`, no pre-release
  (`@pattern ^[0-9]+\.[0-9]+(\.[0-9]+)?$`)

> Node-side `starknet_specVersion` and block-header `starknet_version` stay
> `string` — the spec defines them as inline strings with no pattern.

### proving-api

- Add the new optional `additional_data?: Record<string, unknown>` field to
  `PROVE_TRANSACTION_RESULT` (opaque side-channel relayed verbatim by the prover;
  omitted from the response when absent).

### STRK20 semantic clarifications (comments)

- `STRK20_TRANSFER_ACTION.amount`: `"OPEN"` now means *create a new open note*
  (was "transfer the full opened note balance").
- `STRK20_CALLDATA_PLACEHOLDER` / `STRK20_INVOKE_ACTION`: `${openNoteIds[N]}`
  documented as the ID of the Nth open note (the Nth transfer action with amount
  `"OPEN"`).

> No type change was needed for the rc.3 open-note mismatch rule:
> `INVALID_REQUEST_PAYLOAD` was already in the relevant methods' error unions.

### Spec reference
https://github.com/starkware-libs/starknet-specs/compare/v0.10.3-rc.2...v0.10.3-rc.3

### Validation
- `npm run ts:check` ✅
- `biome lint` (changed files) ✅
