### PR TITLE
ci: bump to node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,9 @@ jobs:
     name: Quality test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run tests on Node lts/*
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'npm'
@@ -44,11 +44,11 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - name: Run Release on Node lts/*
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: 'npm'


### PR DESCRIPTION
## ci: bump GitHub Actions to Node 24 (checkout@v5 / setup-node@v5)

### Context
GitHub Actions emits deprecation warnings because `actions/checkout@v4` and
`actions/setup-node@v4` run on the Node 20 runtime, which is being phased out.

### Changes
In `.github/workflows/publish.yml`, for both the `quality` and `publish` jobs:
- `actions/checkout@v4` → `actions/checkout@v5`
- `actions/setup-node@v4` → `actions/setup-node@v5`

These v5 releases run on the Node 24 runtime, which removes the Node 20
deprecation warning. The `node-version: lts/*` setting is unchanged.

### Impact
- No source/runtime code touched — CI workflow only.
- No behavior change for consumers of the package.
