### PR TITLE
spec RPC v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.10.3-beta.3](https://github.com/starknet-io/types-js/compare/v0.10.3-beta.2...v0.10.3-beta.3) (2026-06-17)
+
+
+### Bug Fixes
+
+* implements spec v0.10.3-rc2 ([93ec752](https://github.com/starknet-io/types-js/commit/93ec7522d850e75aad2d4de60b121b95195367a0))
+
 ## [0.10.3-beta.2](https://github.com/starknet-io/types-js/compare/v0.10.3-beta.1...v0.10.3-beta.2) (2026-06-10)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.10.3-beta.2](https://github.com/starknet-io/types-js/compare/v0.10.3-beta.1...v0.10.3-beta.2) (2026-06-10)
+
+
+### Bug Fixes
+
+* implements spec v 0.10.3-rc1 ([758ee7d](https://github.com/starknet-io/types-js/commit/758ee7d760ac65b8293cd7610a10eba0d74d95e1))
+
 ## [0.10.3-beta.1](https://github.com/starknet-io/types-js/compare/v0.10.2...v0.10.3-beta.1) (2026-06-08)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.10.3-beta.1](https://github.com/starknet-io/types-js/compare/v0.10.2...v0.10.3-beta.1) (2026-06-08)
+
+
+### Bug Fixes
+
+* add missing items from rpc 0.10.2 ([e977073](https://github.com/starknet-io/types-js/commit/e97707319999f9eade49ae0c06b0945f475934be))
+* rpc 0.10.3-rc0 ([d9ae10e](https://github.com/starknet-io/types-js/commit/d9ae10e6bf9a1490a6e1cf4e8937e298a0a37b14))
+* starknet spec v0.10.1-rc.3 ([641bf08](https://github.com/starknet-io/types-js/commit/641bf082f79a42a1776e912706e195cb960dcaa3))
+* update starknet spec v0.10.1-rc.2 ([819a426](https://github.com/starknet-io/types-js/commit/819a426d61f4785f0c16be91f9b7a55462acbf45))
+
 ## [0.10.2](https://github.com/starknet-io/types-js/compare/v0.10.1...v0.10.2) (2026-03-31)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.10.3-beta.4](https://github.com/starknet-io/types-js/compare/v0.10.3-beta.3...v0.10.3-beta.4) (2026-06-30)
+
+
+### Bug Fixes
+
+* implement spec v0.10.3-rc.3 ([c10cb2a](https://github.com/starknet-io/types-js/commit/c10cb2a9a971c9014730d6966fe750226fe90461))
+
 ## [0.10.3-beta.3](https://github.com/starknet-io/types-js/compare/v0.10.3-beta.2...v0.10.3-beta.3) (2026-06-17)
 
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@
 
 ## Installation
 
-RPC 0.10.2 - **latest** (Starknet 0.14.2)
+RPC 0.10.3 - **latest**
+```bash
+npm i @starknet-io/types-js@0.10.3
+```
+
+RPC 0.10.2 - (Starknet 0.14.2)
 ```bash
 npm i @starknet-io/types-js@0.10.2
 ```
@@ -99,6 +104,13 @@ import type { TypedData } from '@starknet-io/types-js';
 ```ts
 // namespace import
 import { PAYMASTER_API } from '@starknet-io/types-js';
+```
+
+#### Proving API [Starknet Transaction Prover API](https://github.com/starkware-libs/starknet-specs/tree/master/proving-api)
+
+```ts
+// namespace import
+import { PROVING_API } from '@starknet-io/types-js';
 ```
 
 ## Versioning

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3",
+  "version": "0.10.3-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.3",
+      "version": "0.10.3-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3-beta.2",
+  "version": "0.10.3-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.3-beta.2",
+      "version": "0.10.3-beta.3",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3-beta.1",
+  "version": "0.10.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.3-beta.1",
+      "version": "0.10.3-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3-beta.3",
+  "version": "0.10.3-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.3-beta.3",
+      "version": "0.10.3-beta.4",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3-beta.1",
+  "version": "0.10.3-beta.2",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3",
+  "version": "0.10.3-beta.1",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3-beta.3",
+  "version": "0.10.3-beta.4",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3-beta.2",
+  "version": "0.10.3-beta.3",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/src/api/components.ts
+++ b/src/api/components.ts
@@ -75,6 +75,17 @@ export type u128 = string
  * A transaction signature
  */
 export type SIGNATURE = Array<FELT>
+
+/**
+ * A STARK proof, encoded as a base64 string
+ * @pattern ^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$
+ */
+export type PROOF = string
+
+/**
+ * Proof facts (felt values) associated with a proven transaction
+ */
+export type PROOF_FACTS = FELT[]
 /**
  * The block number (height) in the blockchain
  * @minimum 0
@@ -809,11 +820,7 @@ export type BROADCASTED_TXN =
  * A broadcasted invoke transaction
  */
 export type BROADCASTED_INVOKE_TXN = INVOKE_TXN_V3 & {
-  /**
-   * Optional proof for the transaction, as a base64 string-encoded byte array
-   * @pattern ^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$
-   */
-  proof?: string
+  proof?: PROOF
 }
 
 /**
@@ -935,7 +942,7 @@ export type INVOKE_TXN_V3 = {
   /**
    * Proof facts for the transaction. An empty array is returned if no proof facts exist for the transaction
    */
-  proof_facts?: FELT[]
+  proof_facts?: PROOF_FACTS
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './api/index.js'
 export * as API from './api/index.js'
 export * as PAYMASTER_API from './snip-29/index.js'
+export * as PROVING_API from './proving-api/index.js'
 export * from './wallet-api/index.js'
 export * as WALLET_API from './wallet-api/index.js'

--- a/src/proving-api/components.ts
+++ b/src/proving-api/components.ts
@@ -1,0 +1,10 @@
+import type { MSG_TO_L1, PROOF, PROOF_FACTS } from '../api/components.js'
+
+/**
+ * The result of proving a transaction
+ */
+export type PROVE_TRANSACTION_RESULT = {
+  proof: PROOF
+  proof_facts: PROOF_FACTS
+  l2_to_l1_messages: MSG_TO_L1[]
+}

--- a/src/proving-api/components.ts
+++ b/src/proving-api/components.ts
@@ -7,4 +7,11 @@ export type PROVE_TRANSACTION_RESULT = {
   proof: PROOF
   proof_facts: PROOF_FACTS
   l2_to_l1_messages: MSG_TO_L1[]
+  /**
+   * Opaque side-channel attached alongside the proof and relayed verbatim by the prover
+   * from the external blocking check service. Optional; omitted from the response when absent.
+   * The prover does not interpret its contents — concrete keys (e.g. a screening signature
+   * under `signature`) are defined by the producing service, not by this API.
+   */
+  additional_data?: Record<string, unknown>
 }

--- a/src/proving-api/errors.ts
+++ b/src/proving-api/errors.ts
@@ -1,0 +1,28 @@
+export interface ACCOUNT_VALIDATION_FAILED {
+  code: 55
+  message: 'Account validation failed'
+  data: string
+}
+
+export interface SERVICE_BUSY {
+  code: -32005
+  message: 'Service is busy'
+  data: string
+}
+
+export interface INVALID_TRANSACTION_INPUT {
+  code: 1000
+  message: 'Invalid transaction input'
+  data: string
+}
+
+export interface UNSUPPORTED_TX_TYPE {
+  code: 1001
+  message: 'the transaction type is not supported'
+  data: string
+}
+
+export interface TRANSACTION_BLOCKED {
+  code: 10000
+  message: 'Transaction blocked'
+}

--- a/src/proving-api/index.ts
+++ b/src/proving-api/index.ts
@@ -1,0 +1,3 @@
+export * from './components.js'
+export * from './errors.js'
+export * from './methods.js'

--- a/src/proving-api/methods.ts
+++ b/src/proving-api/methods.ts
@@ -1,0 +1,26 @@
+import type { BLOCK_ID, BROADCASTED_INVOKE_TXN } from '../api/components.js'
+import * as ApiErrors from '../api/errors.js'
+import type { PROVE_TRANSACTION_RESULT } from './components.js'
+import * as Errors from './errors.js'
+
+export interface RpcTypeToMessageMap {
+  starknet_specVersion: {
+    params?: never
+    result: string
+  }
+
+  starknet_proveTransaction: {
+    params: {
+      block_id: BLOCK_ID
+      transaction: BROADCASTED_INVOKE_TXN
+    }
+    result: PROVE_TRANSACTION_RESULT
+    errors:
+      | ApiErrors.BLOCK_NOT_FOUND
+      | Errors.ACCOUNT_VALIDATION_FAILED
+      | Errors.UNSUPPORTED_TX_TYPE
+      | Errors.SERVICE_BUSY
+      | Errors.INVALID_TRANSACTION_INPUT
+      | Errors.TRANSACTION_BLOCKED
+  }
+}

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -131,6 +131,7 @@ export interface AddStarknetChainParameters extends StarknetChain {}
 
 export interface SwitchStarknetChainParameters {
   chainId: ChainId
+  silent_mode?: boolean
 }
 
 /**

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -73,6 +73,10 @@ export interface AddInvokeTransactionParameters {
    * Calls to invoke by the account
    */
   calls: Call[]
+  /**
+   * Optional ZK proof, required when the transaction was produced by wallet_strk20PrepareInvoke
+   */
+  proof?: STRK20_PROOF
 }
 export interface AddInvokeTransactionResult {
   /**
@@ -148,4 +152,62 @@ export type API_VERSION = string
  */
 export interface ApiVersionRequest {
   api_version?: API_VERSION
+}
+
+// ==================== STRK20 Privacy Protocol ====================
+
+export type STRK20_PROOF = {
+  data: string
+  output: FELT[]
+  proof_facts: FELT[]
+}
+
+export type STRK20_CALL_AND_PROOF = {
+  call: Call
+  proof: STRK20_PROOF
+}
+
+/**
+ * A wallet-resolved placeholder substituted during STRK20 action assembly.
+ * @pattern ^\$\{(?:openNoteIds\[[0-9]+\]|poolAddress)\}$
+ */
+export type STRK20_CALLDATA_PLACEHOLDER = string
+
+export type STRK20_CALLDATA_ITEM = FELT | STRK20_CALLDATA_PLACEHOLDER
+
+export type STRK20_DEPOSIT_ACTION = {
+  type: 'deposit'
+  token: ADDRESS
+  amount: FELT
+}
+
+export type STRK20_WITHDRAW_ACTION = {
+  type: 'withdraw'
+  token: ADDRESS
+  amount: FELT
+  recipient: ADDRESS
+}
+
+export type STRK20_TRANSFER_ACTION = {
+  type: 'transfer'
+  token: ADDRESS
+  amount: FELT
+  recipient: ADDRESS
+}
+
+export type STRK20_INVOKE_ACTION = {
+  type: 'invoke'
+  contract: ADDRESS
+  calldata: STRK20_CALLDATA_ITEM[]
+}
+
+export type STRK20_ACTION =
+  | STRK20_DEPOSIT_ACTION
+  | STRK20_WITHDRAW_ACTION
+  | STRK20_TRANSFER_ACTION
+  | STRK20_INVOKE_ACTION
+
+export type STRK20_BALANCE_ENTRY = {
+  token: ADDRESS
+  balance: FELT
 }

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -20,10 +20,14 @@ export type PADDED_TXN_HASH = PADDED_FELT // TODO: Should be like TXN_HASH_PADDE
 export type PADDED_FELT = string // TODO: STORAGE_KEY should also be PADDED_FELT to remove duplication, and padded felt added to api spec ?
 
 /**
- * A Starknet RPC spec version, only two numbers are provided
- * @pattern ^[0-9]+\\.[0-9]+$
+ * A Starknet JSON-RPC spec version, following semantic versioning.
+ * @pattern ^[0-9]+\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z.-]+)?)?$
+ * @example "0.10" | "0.10.3" | "0.10.3-rc.3"
  */
-export type SpecVersion = string
+export type SpecVersion =
+  | `${number}.${number}`
+  | `${number}.${number}.${number}`
+  | `${number}.${number}.${number}-${string}`
 
 /**
  * ERC20 Token Symbol (min:1 char - max:6 chars)
@@ -147,7 +151,13 @@ export interface AccountDeploymentData {
   version: 0 | 1 // Cairo version (an integer)
 }
 
-export type API_VERSION = string
+/**
+ * A wallet API version, following semantic versioning (no pre-release).
+ * When used as a request parameter and not specified, the latest is assumed.
+ * @pattern ^[0-9]+\\.[0-9]+(\\.[0-9]+)?$
+ * @example "0.8" | "0.10.3"
+ */
+export type API_VERSION = `${number}.${number}` | `${number}.${number}.${number}`
 
 /**
  * The version of wallet API the request expecting. If not specified, the latest is assumed
@@ -185,9 +195,10 @@ export type STRK20_CALL_AND_PROOF = {
 
 /**
  * A wallet-resolved placeholder that the wallet substitutes with a single felt
- * during STRK20 action assembly. ${openNoteIds[N]} expands to the Nth note ID
- * created by openNote actions in the same transaction; ${poolAddress} expands to
- * the privacy pool contract address. N is a zero-based index.
+ * during STRK20 action assembly. ${openNoteIds[N]} expands to the ID of the Nth
+ * open note in the same transaction (i.e. the Nth transfer action with amount
+ * "OPEN"); ${poolAddress} expands to the privacy pool contract address. N is a
+ * zero-based index.
  * @pattern ^\$\{(?:openNoteIds\[[0-9]+\]|poolAddress)\}$
  */
 export type STRK20_CALLDATA_PLACEHOLDER = string
@@ -224,7 +235,7 @@ export type STRK20_WITHDRAW_ACTION = {
 export type STRK20_TRANSFER_ACTION = {
   type: 'transfer'
   token: ADDRESS
-  /** FELT amount, or "OPEN" to transfer the full opened note balance */
+  /** FELT amount in the token's smallest unit, or the literal "OPEN" to create a new open note */
   amount: FELT | 'OPEN'
   recipient: ADDRESS
 }
@@ -233,8 +244,8 @@ export type STRK20_TRANSFER_ACTION = {
  * Invokes an arbitrary contract entry point as part of the same STRK20
  * transaction. Calldata items may be literal felts or wallet-resolved
  * placeholders that the wallet substitutes during action assembly:
- * ${openNoteIds[N]} for the Nth opened note ID, or ${poolAddress} for the privacy
- * pool address.
+ * ${openNoteIds[N]} for the ID of the Nth open note (the Nth transfer action with
+ * amount "OPEN"), or ${poolAddress} for the privacy pool address.
  */
 export type STRK20_INVOKE_ACTION = {
   type: 'invoke'

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -192,7 +192,8 @@ export type STRK20_WITHDRAW_ACTION = {
 export type STRK20_TRANSFER_ACTION = {
   type: 'transfer'
   token: ADDRESS
-  amount: FELT
+  /** FELT amount, or "OPEN" to transfer the full opened note balance */
+  amount: FELT | 'OPEN'
   recipient: ADDRESS
 }
 

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -74,7 +74,8 @@ export interface AddInvokeTransactionParameters {
    */
   calls: Call[]
   /**
-   * Optional ZK proof, required when the transaction was produced by wallet_strk20PrepareInvoke
+   * Optional SNIP-36-compliant ZK proof. Required when submitting a STRK20 call
+   * produced by wallet_strk20PrepareInvoke; omitted for regular invocations.
    */
   proof?: STRK20_PROOF
 }
@@ -157,31 +158,59 @@ export interface ApiVersionRequest {
 
 // ==================== STRK20 Privacy Protocol ====================
 
+/**
+ * SNIP-36-compliant zero-knowledge proof material (an in-protocol stwo-cairo
+ * proof) that must be included with the call when submitting the STRK20
+ * transaction on-chain. When the prepared call was built in simulate mode all
+ * three fields are present but empty.
+ */
 export type STRK20_PROOF = {
   data: string
   output: FELT[]
   proof_facts: FELT[]
 }
 
+/**
+ * A Starknet call that materializes a STRK20 transaction, together with the
+ * SNIP-36-compliant zero-knowledge proof needed to submit it. When produced in
+ * simulate mode the proof fields are present but empty (proof.data is an empty
+ * string, proof.output and proof.proof_facts are empty arrays); in that case the
+ * call is not submittable on-chain and is only useful for fee estimation or UI
+ * previews.
+ */
 export type STRK20_CALL_AND_PROOF = {
   call: Call
   proof: STRK20_PROOF
 }
 
 /**
- * A wallet-resolved placeholder substituted during STRK20 action assembly.
+ * A wallet-resolved placeholder that the wallet substitutes with a single felt
+ * during STRK20 action assembly. ${openNoteIds[N]} expands to the Nth note ID
+ * created by openNote actions in the same transaction; ${poolAddress} expands to
+ * the privacy pool contract address. N is a zero-based index.
  * @pattern ^\$\{(?:openNoteIds\[[0-9]+\]|poolAddress)\}$
  */
 export type STRK20_CALLDATA_PLACEHOLDER = string
 
+/**
+ * A single calldata entry: either a literal felt, or one of the placeholder
+ * strings the wallet expands during action assembly.
+ */
 export type STRK20_CALLDATA_ITEM = FELT | STRK20_CALLDATA_PLACEHOLDER
 
+/**
+ * Deposits public funds from the user's account into the privacy pool. Always to
+ * self.
+ */
 export type STRK20_DEPOSIT_ACTION = {
   type: 'deposit'
   token: ADDRESS
   amount: FELT
 }
 
+/**
+ * Withdraws funds from the privacy pool to a public recipient address.
+ */
 export type STRK20_WITHDRAW_ACTION = {
   type: 'withdraw'
   token: ADDRESS
@@ -189,6 +218,9 @@ export type STRK20_WITHDRAW_ACTION = {
   recipient: ADDRESS
 }
 
+/**
+ * Privately transfers funds inside the privacy pool to another registered user.
+ */
 export type STRK20_TRANSFER_ACTION = {
   type: 'transfer'
   token: ADDRESS
@@ -197,18 +229,32 @@ export type STRK20_TRANSFER_ACTION = {
   recipient: ADDRESS
 }
 
+/**
+ * Invokes an arbitrary contract entry point as part of the same STRK20
+ * transaction. Calldata items may be literal felts or wallet-resolved
+ * placeholders that the wallet substitutes during action assembly:
+ * ${openNoteIds[N]} for the Nth opened note ID, or ${poolAddress} for the privacy
+ * pool address.
+ */
 export type STRK20_INVOKE_ACTION = {
   type: 'invoke'
   contract: ADDRESS
   calldata: STRK20_CALLDATA_ITEM[]
 }
 
+/**
+ * A single action to perform via the STRK20 privacy protocol. The `type` field
+ * discriminates the variant.
+ */
 export type STRK20_ACTION =
   | STRK20_DEPOSIT_ACTION
   | STRK20_WITHDRAW_ACTION
   | STRK20_TRANSFER_ACTION
   | STRK20_INVOKE_ACTION
 
+/**
+ * A private balance for a single token held inside the privacy pool.
+ */
 export type STRK20_BALANCE_ENTRY = {
   token: ADDRESS
   balance: FELT

--- a/src/wallet-api/errors.ts
+++ b/src/wallet-api/errors.ts
@@ -23,6 +23,16 @@ export interface ACCOUNT_ALREADY_DEPLOYED {
   message: 'An error occurred (ACCOUNT_ALREADY_DEPLOYED)'
 }
 
+export interface DEPLOYMENT_DATA_NOT_AVAILABLE {
+  code: 116
+  message: 'An error occurred (DEPLOYMENT_DATA_NOT_AVAILABLE)'
+}
+
+export interface CHAIN_ID_NOT_SUPPORTED {
+  code: 117
+  message: 'An error occurred (CHAIN_ID_NOT_SUPPORTED)'
+}
+
 export interface NOT_REGISTERED {
   code: 118
   message: 'An error occurred (NOT_REGISTERED)'

--- a/src/wallet-api/errors.ts
+++ b/src/wallet-api/errors.ts
@@ -23,6 +23,21 @@ export interface ACCOUNT_ALREADY_DEPLOYED {
   message: 'An error occurred (ACCOUNT_ALREADY_DEPLOYED)'
 }
 
+export interface NOT_REGISTERED {
+  code: 118
+  message: 'An error occurred (NOT_REGISTERED)'
+}
+
+export interface INSUFFICIENT_PRIVATE_BALANCE {
+  code: 119
+  message: 'An error occurred (INSUFFICIENT_PRIVATE_BALANCE)'
+}
+
+export interface PRIVACY_LEAK {
+  code: 120
+  message: 'An error occurred (PRIVACY_LEAK)'
+}
+
 export interface API_VERSION_NOT_SUPPORTED {
   code: 162
   message: 'An error occurred (API_VERSION_NOT_SUPPORTED)'

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -228,6 +228,7 @@ export interface RpcTypeToMessageMap {
    */
   wallet_strk20Balances: {
     params: {
+      /** Token addresses to query. Pass an empty array to return balances of all shielded tokens in the privacy pool. */
       tokens: Address[]
       api_version?: API_VERSION
     }

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -178,8 +178,14 @@ export interface RpcTypeToMessageMap {
   wallet_supportedWalletApi: { params?: never; result: API_VERSION[] }
 
   /**
-   * Execute a STRK20 privacy protocol transaction directly.
-   * @param params The list of STRK20 actions to perform (min 1).
+   * Submit a transaction containing STRK20 privacy protocol actions. Submits one
+   * or more STRK20 actions (deposit, withdraw, private transfer) as a single
+   * atomic transaction. The wallet shows an approval UI and may take
+   * significantly longer than wallet_addInvokeTransaction because SNIP-36 ZK proof
+   * generation is required; the dapp must tolerate long-running calls.
+   * Registration into the pool is transparent — if the user is not registered,
+   * NOT_REGISTERED is returned.
+   * @param params.actions An ordered list of STRK20 actions to execute atomically (min 1).
    * @returns The transaction hash.
    */
   wallet_strk20InvokeTransaction: {
@@ -199,9 +205,15 @@ export interface RpcTypeToMessageMap {
   }
 
   /**
-   * Prepare a STRK20 invoke transaction by building the calldata and generating a ZK proof.
-   * Pass simulate: true to skip proof generation (for fee estimation or preview).
-   * @param params The list of STRK20 actions and optional simulate flag.
+   * Build the Starknet call (and SNIP-36 ZK proof) for a STRK20 transaction
+   * without submitting it. The dapp submits the returned call itself. The wallet
+   * supplies the viewing key and the user's private state (channels, notes); the
+   * dapp only describes the actions. When `simulate` is true the wallet skips the
+   * expensive, state-revealing proof generation and returns the call with an empty
+   * proof — same shape, but NOT submittable on-chain (use for fee estimation / UI
+   * previews). NOT_REGISTERED if the user is not registered.
+   * @param params.actions An ordered list of STRK20 actions to bundle (min 1).
+   * @param params.simulate If true, skip proof generation and return an empty proof. Defaults to false.
    * @returns The assembled call and proof (proof fields are empty when simulate is true).
    */
   wallet_strk20PrepareInvoke: {
@@ -222,8 +234,11 @@ export interface RpcTypeToMessageMap {
   }
 
   /**
-   * Get STRK20 private balances for the given tokens.
-   * @param params The list of token addresses to query (min 1).
+   * Query the user's private balances for a list of tokens, or for all shielded
+   * tokens. Returns the private balance held inside the pool for each requested
+   * token address; an empty array returns balances of all shielded tokens the
+   * wallet holds. NOT_REGISTERED if the user is not registered.
+   * @param params.tokens Token addresses to query; an empty array returns all shielded tokens.
    * @returns Balance per token.
    */
   wallet_strk20Balances: {

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -91,6 +91,7 @@ export interface RpcTypeToMessageMap {
       | Errors.UNLISTED_NETWORK
       | Errors.USER_REFUSED_OP
       | Errors.API_VERSION_NOT_SUPPORTED
+      | Errors.CHAIN_ID_NOT_SUPPORTED
       | Errors.UNKNOWN_ERROR
   }
 
@@ -113,6 +114,7 @@ export interface RpcTypeToMessageMap {
     result: AccountDeploymentData
     errors:
       | Errors.ACCOUNT_ALREADY_DEPLOYED
+      | Errors.DEPLOYMENT_DATA_NOT_AVAILABLE
       | Errors.API_VERSION_NOT_SUPPORTED
       | Errors.UNKNOWN_ERROR
   }

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -9,9 +9,13 @@ import type {
   AddStarknetChainParameters,
   API_VERSION,
   ApiVersionRequest,
+  PADDED_TXN_HASH,
   RequestAccountsParameters,
   Signature,
   SpecVersion,
+  STRK20_ACTION,
+  STRK20_BALANCE_ENTRY,
+  STRK20_CALL_AND_PROOF,
   SwitchStarknetChainParameters,
   WatchAssetParameters,
 } from './components.js'
@@ -170,6 +174,69 @@ export interface RpcTypeToMessageMap {
    * @returns An array of supported wallet api versions.
    */
   wallet_supportedWalletApi: { params?: never; result: API_VERSION[] }
+
+  /**
+   * Execute a STRK20 privacy protocol transaction directly.
+   * @param params The list of STRK20 actions to perform (min 1).
+   * @returns The transaction hash.
+   */
+  wallet_strk20InvokeTransaction: {
+    params: {
+      actions: STRK20_ACTION[]
+      api_version?: API_VERSION
+    }
+    result: { transaction_hash: PADDED_TXN_HASH }
+    errors:
+      | Errors.NOT_REGISTERED
+      | Errors.INSUFFICIENT_PRIVATE_BALANCE
+      | Errors.PRIVACY_LEAK
+      | Errors.INVALID_REQUEST_PAYLOAD
+      | Errors.USER_REFUSED_OP
+      | Errors.API_VERSION_NOT_SUPPORTED
+      | Errors.UNKNOWN_ERROR
+  }
+
+  /**
+   * Prepare a STRK20 invoke transaction by building the calldata and generating a ZK proof.
+   * Pass simulate: true to skip proof generation (for fee estimation or preview).
+   * @param params The list of STRK20 actions and optional simulate flag.
+   * @returns The assembled call and proof (proof fields are empty when simulate is true).
+   */
+  wallet_strk20PrepareInvoke: {
+    params: {
+      actions: STRK20_ACTION[]
+      simulate?: boolean
+      api_version?: API_VERSION
+    }
+    result: STRK20_CALL_AND_PROOF
+    errors:
+      | Errors.NOT_REGISTERED
+      | Errors.INSUFFICIENT_PRIVATE_BALANCE
+      | Errors.PRIVACY_LEAK
+      | Errors.INVALID_REQUEST_PAYLOAD
+      | Errors.USER_REFUSED_OP
+      | Errors.API_VERSION_NOT_SUPPORTED
+      | Errors.UNKNOWN_ERROR
+  }
+
+  /**
+   * Get STRK20 private balances for the given tokens.
+   * @param params The list of token addresses to query (min 1).
+   * @returns Balance per token.
+   */
+  wallet_strk20Balances: {
+    params: {
+      tokens: Address[]
+      api_version?: API_VERSION
+    }
+    result: STRK20_BALANCE_ENTRY[]
+    errors:
+      | Errors.NOT_REGISTERED
+      | Errors.INVALID_REQUEST_PAYLOAD
+      | Errors.USER_REFUSED_OP
+      | Errors.API_VERSION_NOT_SUPPORTED
+      | Errors.UNKNOWN_ERROR
+  }
 }
 
 export type RpcMessage = {


### PR DESCRIPTION
## Promote beta → main: RPC 0.10.3 (stable release)

Promotes `beta` to `main` to trigger the stable `0.10.3` release
(semantic-release, patch bump from `0.10.2`).

### Included
- **New `PROVING_API` module** — `PROVE_TRANSACTION_RESULT`, `PROOF`,
  `PROOF_FACTS`, typed errors; namespace-only export.
- **Wallet API STRK20** (note-based privacy, SNIP-36) — `STRK20_*` types &
  actions, errors (`NOT_REGISTERED`, `INSUFFICIENT_PRIVATE_BALANCE`,
  `PRIVACY_LEAK`, …), and methods `wallet_strk20InvokeTransaction`,
  `wallet_strk20PrepareInvoke`, `wallet_strk20Balances`.
- `API_VERSION` type + new `SpecVersion` values.
- README: RPC 0.10.3 marked **latest / stable**.
