### PR TITLE
Rpc 0.10.4 rc.0 beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.10.3](https://github.com/starknet-io/types-js/compare/v0.10.2...v0.10.3) (2026-07-01)
+
+
+### Bug Fixes
+
+* add missing items from rpc 0.10.2 ([e977073](https://github.com/starknet-io/types-js/commit/e97707319999f9eade49ae0c06b0945f475934be))
+* implement spec v0.10.3-rc.3 ([c10cb2a](https://github.com/starknet-io/types-js/commit/c10cb2a9a971c9014730d6966fe750226fe90461))
+* implements spec v 0.10.3-rc1 ([758ee7d](https://github.com/starknet-io/types-js/commit/758ee7d760ac65b8293cd7610a10eba0d74d95e1))
+* implements spec v0.10.3-rc2 ([93ec752](https://github.com/starknet-io/types-js/commit/93ec7522d850e75aad2d4de60b121b95195367a0))
+* rpc 0.10.3-rc0 ([d9ae10e](https://github.com/starknet-io/types-js/commit/d9ae10e6bf9a1490a6e1cf4e8937e298a0a37b14))
+* starknet spec v0.10.1-rc.3 ([641bf08](https://github.com/starknet-io/types-js/commit/641bf082f79a42a1776e912706e195cb960dcaa3))
+* update starknet spec v0.10.1-rc.2 ([819a426](https://github.com/starknet-io/types-js/commit/819a426d61f4785f0c16be91f9b7a55462acbf45))
+
 ## [0.10.3-beta.4](https://github.com/starknet-io/types-js/compare/v0.10.3-beta.3...v0.10.3-beta.4) (2026-06-30)
 
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,18 @@
 
 ## Installation
 
+RPC 0.10.4 - **beta** (stable not yet released)
+
+| npm version | Spec |
+|---|---|
+| `npm i @starknet-io/types-js@0.10.4-beta.1` | rc0 - latest beta |
 
 RPC 0.10.3 - **latest**
 ```bash
 npm i @starknet-io/types-js@0.10.3
+```
 
+RPC 0.10.2 - (Starknet 0.14.2)
 ```bash
 npm i @starknet-io/types-js@0.10.2
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3-beta.4",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.3-beta.4",
+      "version": "0.10.3",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3",
+  "version": "0.10.4-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.3",
+      "version": "0.10.4-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3-beta.4",
+  "version": "0.10.3",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3",
+  "version": "0.10.4-beta.1",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -22,7 +22,7 @@ export type PADDED_FELT = string // TODO: STORAGE_KEY should also be PADDED_FELT
 /**
  * A Starknet JSON-RPC spec version, following semantic versioning.
  * @pattern ^[0-9]+\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z.-]+)?)?$
- * @example "0.10" | "0.10.3" | "0.10.3-rc.3"
+ * @example "0.10" | "0.10.4" | "0.10.4-rc.0"
  */
 export type SpecVersion =
   | `${number}.${number}`
@@ -155,7 +155,7 @@ export interface AccountDeploymentData {
  * A wallet API version, following semantic versioning (no pre-release).
  * When used as a request parameter and not specified, the latest is assumed.
  * @pattern ^[0-9]+\\.[0-9]+(\\.[0-9]+)?$
- * @example "0.8" | "0.10.3"
+ * @example "0.8" | "0.10.4"
  */
 export type API_VERSION = `${number}.${number}` | `${number}.${number}.${number}`
 
@@ -254,6 +254,52 @@ export type STRK20_INVOKE_ACTION = {
 }
 
 /**
+ * Identifies the dapp that scopes a set of STRK20 sub-accounts, as a single
+ * felt. Either a 0x-prefixed felt, or a human-readable ASCII string of at most
+ * 31 characters that the wallet encodes as a Cairo short string.
+ */
+export type STRK20_DAPP_NAME = string
+
+/**
+ * How much of the sub-account's token balance a settled open note collects.
+ * 'all' collects the sub-account's entire token balance; 'diff' collects only
+ * the balance gained during this interaction; 'exact' collects the given amount
+ * (which must be provided).
+ */
+export type STRK20_COLLECT_POLICY =
+  | { type: 'all' }
+  | { type: 'diff' }
+  | {
+      type: 'exact'
+      /** The exact amount to collect, in the token's smallest unit. */
+      amount: FELT
+    }
+
+/**
+ * Invokes one or more contract calls through the user's STRK20 sub-account for a
+ * dapp, routed via the sub-account anonymizer. The sub-account is selected by
+ * (dapp_name, nonce); each nonce maps to a distinct, deterministic sub-account.
+ * The proceeds of the calls are settled into the open notes created by transfer
+ * actions with amount "OPEN" in the same transaction, so the usual rule applies:
+ * the number of open notes filled by this action must match the number of open
+ * notes created in the transaction.
+ */
+export type STRK20_SUBACCOUNT_INVOKE_ACTION = {
+  type: 'subaccount_invoke'
+  /** The dapp that scopes the sub-account */
+  dapp_name: STRK20_DAPP_NAME
+  /** The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp */
+  nonce: FELT
+  /** The contract calls to execute through the sub-account, in order (min 1). */
+  calls: Call[]
+  /**
+   * A single policy applied to every open note this action settles: how much of
+   * the sub-account's balance each note collects.
+   */
+  collect_policy: STRK20_COLLECT_POLICY
+}
+
+/**
  * A single action to perform via the STRK20 privacy protocol. The `type` field
  * discriminates the variant.
  */
@@ -262,6 +308,7 @@ export type STRK20_ACTION =
   | STRK20_WITHDRAW_ACTION
   | STRK20_TRANSFER_ACTION
   | STRK20_INVOKE_ACTION
+  | STRK20_SUBACCOUNT_INVOKE_ACTION
 
 /**
  * A private balance for a single token held inside the privacy pool.

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -1,3 +1,4 @@
+import type { FELT } from '../api/components.js'
 import type { ChainId } from '../api/index.js'
 import type {
   AccountDeploymentData,
@@ -16,6 +17,7 @@ import type {
   STRK20_ACTION,
   STRK20_BALANCE_ENTRY,
   STRK20_CALL_AND_PROOF,
+  STRK20_DAPP_NAME,
   SwitchStarknetChainParameters,
   WatchAssetParameters,
 } from './components.js'
@@ -182,7 +184,9 @@ export interface RpcTypeToMessageMap {
    * or more STRK20 actions (deposit, withdraw, private transfer) as a single
    * atomic transaction. The wallet shows an approval UI and may take
    * significantly longer than wallet_addInvokeTransaction because SNIP-36 ZK proof
-   * generation is required; the dapp must tolerate long-running calls.
+   * generation is required; the dapp must tolerate long-running calls. The wallet
+   * adds the fee action itself: a withdraw action covering the paymaster/relayer
+   * fee required to submit, on top of the actions the dapp supplies.
    * Registration into the pool is transparent — if the user is not registered,
    * NOT_REGISTERED is returned.
    * @param params.actions An ordered list of STRK20 actions to execute atomically (min 1).
@@ -208,7 +212,9 @@ export interface RpcTypeToMessageMap {
    * Build the Starknet call (and SNIP-36 ZK proof) for a STRK20 transaction
    * without submitting it. The dapp submits the returned call itself. The wallet
    * supplies the viewing key and the user's private state (channels, notes); the
-   * dapp only describes the actions. When `simulate` is true the wallet skips the
+   * dapp only describes the actions. The wallet does not add a fee withdrawal
+   * action — the fee belongs to whoever submits, so the dapp covers it (for
+   * instance through its own paymaster). When `simulate` is true the wallet skips the
    * expensive, state-revealing proof generation and returns the call with an empty
    * proof — same shape, but NOT submittable on-chain (use for fee estimation / UI
    * previews). NOT_REGISTERED if the user is not registered.
@@ -248,6 +254,37 @@ export interface RpcTypeToMessageMap {
       api_version?: API_VERSION
     }
     result: STRK20_BALANCE_ENTRY[]
+    errors:
+      | Errors.NOT_REGISTERED
+      | Errors.INVALID_REQUEST_PAYLOAD
+      | Errors.USER_REFUSED_OP
+      | Errors.API_VERSION_NOT_SUPPORTED
+      | Errors.UNKNOWN_ERROR
+  }
+
+  /**
+   * Compute the commitment for a dapp's STRK20 sub-accounts. The commitment is
+   * computed locally by the wallet from the user's private state; no transaction
+   * is sent. When `nonce` is given, returns the full commitment for that single
+   * sub-account: hash(partial_commitment, nonce); each nonce maps to a distinct,
+   * deterministic sub-account for the user + dapp. When `nonce` is omitted,
+   * returns the partial (nonce-independent) commitment: hash(identity_key,
+   * dapp_name), where identity_key is derived from the user, their viewing key,
+   * and the sub-account anonymizer address. The partial commitment is shared by
+   * every sub-account the user derives for this dapp, so it can be published once
+   * to let a dapp recognize all of the user's sub-accounts without learning any
+   * individual nonce. NOT_REGISTERED if the user is not registered.
+   * @param params.dapp_name The dapp that scopes the sub-account(s).
+   * @param params.nonce The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp. When omitted, the partial commitment is returned instead.
+   * @returns The sub-account commitment: hash(partial_commitment, nonce) when `nonce` was given, otherwise the partial commitment hash(identity_key, dapp_name).
+   */
+  wallet_strk20SubaccountCommitment: {
+    params: {
+      dapp_name: STRK20_DAPP_NAME
+      nonce?: FELT
+      api_version?: API_VERSION
+    }
+    result: FELT
     errors:
       | Errors.NOT_REGISTERED
       | Errors.INVALID_REQUEST_PAYLOAD


### PR DESCRIPTION
## Summary

Adds the wallet API types for **STRK20 sub-accounts**, and clarifies who pays the fee
in the two STRK20 invoke methods. Also brings `beta` up to date with `main`.

Target version: **0.10.4-beta.1**.

## Changes

**`src/wallet-api/components.ts`**
- `STRK20_DAPP_NAME` — identifies the dapp scoping a set of sub-accounts, as a single felt.
- `STRK20_COLLECT_POLICY` — how much of the sub-account balance a settled open note
  collects: `all`, `diff`, or `exact` with an amount.
- `STRK20_SUBACCOUNT_INVOKE_ACTION` — new `subaccount_invoke` action, routing calls
  through the user's sub-account selected by `(dapp_name, nonce)`. Added to `STRK20_ACTION`.

**`src/wallet-api/methods.ts`**
- `wallet_strk20SubaccountCommitment` — new method, computed locally by the wallet with
  no transaction sent. With `nonce`, returns the full commitment; without it, the partial
  commitment shared by all of the user's sub-accounts for that dapp.
- Fee handling now documented, since it differs: `wallet_strk20InvokeTransaction` adds the
  fee withdrawal itself, `wallet_strk20PrepareInvoke` does not (the submitter pays).
