### PR TITLE
fix: rename STRK20 sub-accounts to shadow accounts (spec PR 406)

### DIFF
--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -254,17 +254,17 @@ export type STRK20_INVOKE_ACTION = {
 }
 
 /**
- * Identifies the dapp that scopes a set of STRK20 sub-accounts, as a single
+ * Identifies the dapp that scopes a set of STRK20 shadow accounts, as a single
  * felt. Either a 0x-prefixed felt, or a human-readable ASCII string of at most
  * 31 characters that the wallet encodes as a Cairo short string.
  */
 export type STRK20_DAPP_NAME = string
 
 /**
- * How much of the sub-account's token balance a settled open note collects.
- * 'all' collects the sub-account's entire token balance; 'diff' collects only
- * the balance gained during this interaction; 'exact' collects the given amount
- * (which must be provided).
+ * How much of the shadow account's token balance a settled open note
+ * collects. 'all' collects the shadow account's entire token balance; 'diff'
+ * collects only the balance gained during this interaction; 'exact' collects
+ * the given amount (which must be provided).
  */
 export type STRK20_COLLECT_POLICY =
   | { type: 'all' }
@@ -276,25 +276,25 @@ export type STRK20_COLLECT_POLICY =
     }
 
 /**
- * Invokes one or more contract calls through the user's STRK20 sub-account for a
- * dapp, routed via the sub-account anonymizer. The sub-account is selected by
- * (dapp_name, nonce); each nonce maps to a distinct, deterministic sub-account.
- * The proceeds of the calls are settled into the open notes created by transfer
- * actions with amount "OPEN" in the same transaction, so the usual rule applies:
- * the number of open notes filled by this action must match the number of open
- * notes created in the transaction.
+ * Invokes one or more contract calls through the user's STRK20 shadow account
+ * for a dapp, routed via the shadow account anonymizer. The shadow account is
+ * selected by (dapp_name, nonce); each nonce maps to a distinct, deterministic
+ * shadow account. The proceeds of the calls are settled into the open notes
+ * created by transfer actions with amount "OPEN" in the same transaction, so the
+ * usual rule applies: the number of open notes filled by this action must match
+ * the number of open notes created in the transaction.
  */
-export type STRK20_SUBACCOUNT_INVOKE_ACTION = {
-  type: 'subaccount_invoke'
-  /** The dapp that scopes the sub-account */
+export type STRK20_SHADOW_ACCOUNT_INVOKE_ACTION = {
+  type: 'shadow_account_invoke'
+  /** The dapp that scopes the shadow account */
   dapp_name: STRK20_DAPP_NAME
-  /** The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp */
+  /** The shadow account nonce; each nonce selects a distinct shadow account for this user + dapp */
   nonce: FELT
-  /** The contract calls to execute through the sub-account, in order (min 1). */
+  /** The contract calls to execute through the shadow account, in order (min 1). */
   calls: Call[]
   /**
    * A single policy applied to every open note this action settles: how much of
-   * the sub-account's balance each note collects.
+   * the shadow account's balance each note collects.
    */
   collect_policy: STRK20_COLLECT_POLICY
 }
@@ -308,7 +308,7 @@ export type STRK20_ACTION =
   | STRK20_WITHDRAW_ACTION
   | STRK20_TRANSFER_ACTION
   | STRK20_INVOKE_ACTION
-  | STRK20_SUBACCOUNT_INVOKE_ACTION
+  | STRK20_SHADOW_ACCOUNT_INVOKE_ACTION
 
 /**
  * A private balance for a single token held inside the privacy pool.

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -263,22 +263,23 @@ export interface RpcTypeToMessageMap {
   }
 
   /**
-   * Compute the commitment for a dapp's STRK20 sub-accounts. The commitment is
-   * computed locally by the wallet from the user's private state; no transaction
-   * is sent. When `nonce` is given, returns the full commitment for that single
-   * sub-account: hash(partial_commitment, nonce); each nonce maps to a distinct,
-   * deterministic sub-account for the user + dapp. When `nonce` is omitted,
-   * returns the partial (nonce-independent) commitment: hash(identity_key,
-   * dapp_name), where identity_key is derived from the user, their viewing key,
-   * and the sub-account anonymizer address. The partial commitment is shared by
-   * every sub-account the user derives for this dapp, so it can be published once
-   * to let a dapp recognize all of the user's sub-accounts without learning any
-   * individual nonce. NOT_REGISTERED if the user is not registered.
-   * @param params.dapp_name The dapp that scopes the sub-account(s).
-   * @param params.nonce The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp. When omitted, the partial commitment is returned instead.
-   * @returns The sub-account commitment: hash(partial_commitment, nonce) when `nonce` was given, otherwise the partial commitment hash(identity_key, dapp_name).
+   * Compute the commitment for a dapp's STRK20 shadow accounts. The commitment
+   * is computed locally by the wallet from the user's private state; no
+   * transaction is sent. When `nonce` is given, returns the full commitment for
+   * that single shadow account: hash(partial_commitment, nonce); each nonce maps
+   * to a distinct, deterministic shadow account for the user + dapp. When
+   * `nonce` is omitted, returns the partial (nonce-independent) commitment:
+   * hash(identity_key, dapp_name), where identity_key is derived from the user,
+   * their viewing key, and the shadow account anonymizer address. The partial
+   * commitment is shared by every shadow account the user derives for this dapp,
+   * so it can be published once to let a dapp recognize all of the user's shadow
+   * accounts without learning any individual nonce. NOT_REGISTERED if the user
+   * is not registered.
+   * @param params.dapp_name The dapp that scopes the shadow account(s).
+   * @param params.nonce The shadow account nonce; each nonce selects a distinct shadow account for this user + dapp. When omitted, the partial commitment is returned instead.
+   * @returns The shadow account commitment: hash(partial_commitment, nonce) when `nonce` was given, otherwise the partial commitment hash(identity_key, dapp_name).
    */
-  wallet_strk20SubaccountCommitment: {
+  wallet_strk20ShadowAccountCommitment: {
     params: {
       dapp_name: STRK20_DAPP_NAME
       nonce?: FELT


### PR DESCRIPTION
## Summary

Applies [starknet-specs PR #406](https://github.com/starkware-libs/starknet-specs/pull/406)
(merged 2026-08-11): the STRK20 **sub-account** concept is renamed to **shadow account**
across the wallet API. Terminology only — no semantic or structural change.

Target version: **0.10.4-beta.2**.

## Breaking (wire-visible)

| Before | After |
|---|---|
| `wallet_strk20SubaccountCommitment` | `wallet_strk20ShadowAccountCommitment` |
| `STRK20_SUBACCOUNT_INVOKE_ACTION` | `STRK20_SHADOW_ACCOUNT_INVOKE_ACTION` |
| `"subaccount_invoke"` (action discriminator) | `"shadow_account_invoke"` |

`STRK20_SUBACCOUNT_INVOKE_ACTION` is re-exported both flat and under `WALLET_API`, so
consumers importing it need to update. No deprecated alias is provided: STRK20 only
landed in `0.10.3`, the `0.10.4` line is still in beta, and an alias would not have
covered the two other changes — the RPC method key and the `"subaccount_invoke"`
discriminator are wire values, not types.

## Changes

**`src/wallet-api/components.ts`**
- `STRK20_SUBACCOUNT_INVOKE_ACTION` → `STRK20_SHADOW_ACCOUNT_INVOKE_ACTION`, with its
  `type` discriminator `'subaccount_invoke'` → `'shadow_account_invoke'`.
- `STRK20_ACTION` union member updated accordingly.
- Doc comments of `STRK20_DAPP_NAME`, `STRK20_COLLECT_POLICY` and the invoke action
  realigned word-for-word on the new spec wording (including "shadow account anonymizer").

**`src/wallet-api/methods.ts`**
- `wallet_strk20SubaccountCommitment` → `wallet_strk20ShadowAccountCommitment`. Params,
  result and error set are unchanged.
- Method doc realigned on the new spec wording.

## Validation

- `npm run ts:check` — passes.
- `./node_modules/.bin/biome lint --write .` — no fixes applied.
- `grep -riE "sub[_ -]?account" src/` — no occurrence left.
