### PR TITLE
Rpc 0.10.4 rc.2 beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ RPC 0.10.4 - **beta** (stable not yet released)
 
 | npm version | Spec |
 |---|---|
-| `npm i @starknet-io/types-js@0.10.4-beta.1` | rc0 - latest beta |
+| `npm i @starknet-io/types-js@0.10.4-beta.3` | rc2 - latest beta |
+| `npm i @starknet-io/types-js@0.10.4-beta.2` | rc1 |
+| `npm i @starknet-io/types-js@0.10.4-beta.1` | rc0 |
 
 RPC 0.10.3 - **latest**
 ```bash

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -273,25 +273,6 @@ export const ETransactionVersion = {
 } as const
 
 export type ETransactionVersion = (typeof ETransactionVersion)[keyof typeof ETransactionVersion]
-/**
- * Old Transaction Versions
- */
-
-/**
- * @deprecated Starknet 0.14 will not support this transaction
- */
-export const ETransactionVersion2 = {
-  V0: ETransactionVersion.V0,
-  V1: ETransactionVersion.V1,
-  V2: ETransactionVersion.V2,
-  F0: ETransactionVersion.F0,
-  F1: ETransactionVersion.F1,
-  F2: ETransactionVersion.F2,
-} as const
-/**
- * @deprecated Starknet 0.14 will not support this transaction
- */
-export type ETransactionVersion2 = (typeof ETransactionVersion2)[keyof typeof ETransactionVersion2]
 
 /**
  * V3 Transaction Versions

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -114,7 +114,7 @@ export interface INSUFFICIENT_RESOURCES_FOR_VALIDATE {
 
 export interface INSUFFICIENT_ACCOUNT_BALANCE {
   code: 54
-  message: "Account balance is smaller than the transaction's max_fee"
+  message: "Account balance is smaller than the transaction's maximal fee (calculated as the sum of each resource's limit x max price)"
 }
 
 export interface VALIDATION_FAILURE {

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -69,7 +69,7 @@ export type Call = {
 }
 
 /**
- * INVOKE_TXN_V1
+ * INVOKE_TXN_V3
  * @see https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json
  */
 export interface AddInvokeTransactionParameters {

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -245,12 +245,15 @@ export interface RpcTypeToMessageMap {
    * token address; an empty array returns balances of all shielded tokens the
    * wallet holds. NOT_REGISTERED if the user is not registered.
    * @param params.tokens Token addresses to query; an empty array returns all shielded tokens.
+   * @param params.valid_until Expiry of the balance-read authorization, as a Unix timestamp in seconds; if omitted, the wallet applies its own default window.
    * @returns Balance per token.
    */
   wallet_strk20Balances: {
     params: {
       /** Token addresses to query. Pass an empty array to return balances of all shielded tokens in the privacy pool. */
       tokens: Address[]
+      /** Requested expiry of the balance-read authorization, as a Unix timestamp in seconds. When omitted, the wallet applies its own default window. */
+      valid_until?: number
       api_version?: API_VERSION
     }
     result: STRK20_BALANCE_ENTRY[]


### PR DESCRIPTION
## Summary

Implements [starknet-specs `v0.10.4-rc.2`](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.4-rc.2):
adds an expiry parameter to the STRK20 balance-read method. Also cleans up leftover
v1-transaction references found while working on this branch.

Target version: **0.10.4-beta.3**.

## Changes

**`src/wallet-api/methods.ts`**
- `wallet_strk20Balances` — new optional `valid_until` param: Unix timestamp expiry for
  the balance-read authorization; the wallet applies its own default window when omitted.

**`src/api/constants.ts`**
- Removed `ETransactionVersion2` (non-spec, already-deprecated v1-only leftover).

**`src/api/errors.ts`**
- `INSUFFICIENT_ACCOUNT_BALANCE.message` realigned on spec `0.10.4-rc.1` wording
  (`max_fee` is a v1 concept; V3 uses resource bounds).

**`src/wallet-api/components.ts`**
- Fixed stale `INVOKE_TXN_V1` JSDoc on `AddInvokeTransactionParameters` → `INVOKE_TXN_V3`.

**`README.md`**
- Added the `rc1` / `rc2` rows to the 0.10.4 beta table (it had been stuck at `rc0` since
  `rc.1` shipped as `beta.2`).

## Validation

- `npm run ts:check` — passes.
- `./node_modules/.bin/biome check src/wallet-api/methods.ts` — no fixes needed.
