### PR TITLE
docs: mark RPC 0.10.4 as latest stable, unpin spec links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width='300' src="https://raw.githubusercontent.com/starknet-io/types-js/9c98311bfdeda3440b0d65d2eaa3c5869ddedcab/types%20js%20logo.png">
+  <img width='300' src="https://raw.githubusercontent.com/starknet-io/types-js/main/types%20js%20logo.png">
 </p>
 <p align="center">
     <a href="https://github.com/starknet-io/types-js/actions/workflows/publish.yml">
@@ -43,15 +43,12 @@
 
 ## Installation
 
-RPC 0.10.4 - **beta** (stable not yet released)
+RPC 0.10.4 - **latest**
+```bash
+npm i @starknet-io/types-js@0.10.4
+```
 
-| npm version | Spec |
-|---|---|
-| `npm i @starknet-io/types-js@0.10.4-beta.3` | rc2 - latest beta |
-| `npm i @starknet-io/types-js@0.10.4-beta.2` | rc1 |
-| `npm i @starknet-io/types-js@0.10.4-beta.1` | rc0 |
-
-RPC 0.10.3 - **latest**
+RPC 0.10.3
 ```bash
 npm i @starknet-io/types-js@0.10.3
 ```
@@ -89,7 +86,7 @@ import type { SomeApiType } from '@starknet-io/types-js';
 import { API } from '@starknet-io/types-js';
 ```
 
-#### Wallet API [Wallet JSON RPC Specification](https://github.com/starkware-libs/starknet-specs/tree/48e77bf4aaf687388b40b8198e3105401941517a/wallet-api)
+#### Wallet API [Wallet JSON RPC Specification](https://github.com/starkware-libs/starknet-specs/tree/master/wallet-api)
 
 ```ts
 // type import


### PR DESCRIPTION
## Summary

Spec [`v0.10.4`](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.4) is
final. Verified against `v0.10.4-rc.2` via the GitHub compare API: the only differences are
the `"version"` strings in the 11 spec/package files — **no semantic change**, so the types
already shipped in `0.10.4-beta.3` are complete and need no update.

This PR only brings the README in line with the imminent stable release, ahead of the
`beta` → `main` promotion.

## Changes

**`README.md`**
- RPC 0.10.4 is now marked **latest**, with its plain `npm i` install block; the three-row
  beta table is dropped (same treatment the `0.10.3-beta.x` series got once 0.10.3 shipped).
- RPC 0.10.3 demoted to a plain history entry.
- Wallet API spec link unpinned from commit `48e77bf` (an **April 2024** revision, predating
  STRK20 and shadow accounts) to `master`, matching the sibling API and Proving API links.
- Logo image unpinned from commit `9c98311` to `main` (file verified present on that branch).

## Validation

- No source file touched — types unchanged since `0.10.4-beta.3`.
- Commit-type audit of `main..beta`: 4 × `fix:`, 3 × `chore(release):`, 1 × `chore:`, no
  `feat:` and no `BREAKING CHANGE` footer → the promotion will resolve to a **patch** bump
  from `0.10.3`, i.e. **`0.10.4`**, preserving package ↔ spec alignment.
