### PR TITLE
spec RPC 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.10.4-beta.1](https://github.com/starknet-io/types-js/compare/v0.10.3...v0.10.4-beta.1) (2026-07-29)
+
+
+### Bug Fixes
+
+* sub-accounts handling ([1a46a02](https://github.com/starknet-io/types-js/commit/1a46a02286a7704a0eae86d1556ff2adfae56498))
+
 ## [0.10.3](https://github.com/starknet-io/types-js/compare/v0.10.2...v0.10.3) (2026-07-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.10.4-beta.2](https://github.com/starknet-io/types-js/compare/v0.10.4-beta.1...v0.10.4-beta.2) (2026-08-13)
+
+
+### Bug Fixes
+
+* rename STRK20 sub-accounts to shadow accounts (spec PR 406) ([1c06e74](https://github.com/starknet-io/types-js/commit/1c06e74b456b0519f378f9bffb3e41356deb7a63))
+
 ## [0.10.4-beta.1](https://github.com/starknet-io/types-js/compare/v0.10.3...v0.10.4-beta.1) (2026-07-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.10.4-beta.3](https://github.com/starknet-io/types-js/compare/v0.10.4-beta.2...v0.10.4-beta.3) (2026-09-10)
+
+
+### Bug Fixes
+
+* implement spec v0.10.4-rc.2 ([bd25569](https://github.com/starknet-io/types-js/commit/bd2556990c1dcd90c4982b073b3512515564b520))
+* remove leftover v1 transaction references ([e1551d5](https://github.com/starknet-io/types-js/commit/e1551d5636b9892b2e6e622894e17230a2672002))
+
 ## [0.10.4-beta.2](https://github.com/starknet-io/types-js/compare/v0.10.4-beta.1...v0.10.4-beta.2) (2026-08-13)
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width='300' src="https://raw.githubusercontent.com/starknet-io/types-js/9c98311bfdeda3440b0d65d2eaa3c5869ddedcab/types%20js%20logo.png">
+  <img width='300' src="https://raw.githubusercontent.com/starknet-io/types-js/main/types%20js%20logo.png">
 </p>
 <p align="center">
     <a href="https://github.com/starknet-io/types-js/actions/workflows/publish.yml">
@@ -43,15 +43,12 @@
 
 ## Installation
 
-RPC 0.10.4 - **beta** (stable not yet released)
+RPC 0.10.4 - **latest**
+```bash
+npm i @starknet-io/types-js@0.10.4
+```
 
-| npm version | Spec |
-|---|---|
-| `npm i @starknet-io/types-js@0.10.4-beta.3` | rc2 - latest beta |
-| `npm i @starknet-io/types-js@0.10.4-beta.2` | rc1 |
-| `npm i @starknet-io/types-js@0.10.4-beta.1` | rc0 |
-
-RPC 0.10.3 - **latest**
+RPC 0.10.3
 ```bash
 npm i @starknet-io/types-js@0.10.3
 ```
@@ -89,7 +86,7 @@ import type { SomeApiType } from '@starknet-io/types-js';
 import { API } from '@starknet-io/types-js';
 ```
 
-#### Wallet API [Wallet JSON RPC Specification](https://github.com/starkware-libs/starknet-specs/tree/48e77bf4aaf687388b40b8198e3105401941517a/wallet-api)
+#### Wallet API [Wallet JSON RPC Specification](https://github.com/starkware-libs/starknet-specs/tree/master/wallet-api)
 
 ```ts
 // type import

--- a/README.md
+++ b/README.md
@@ -43,11 +43,18 @@
 
 ## Installation
 
+RPC 0.10.4 - **beta** (stable not yet released)
+
+| npm version | Spec |
+|---|---|
+| `npm i @starknet-io/types-js@0.10.4-beta.1` | rc0 - latest beta |
 
 RPC 0.10.3 - **latest**
 ```bash
 npm i @starknet-io/types-js@0.10.3
+```
 
+RPC 0.10.2 - (Starknet 0.14.2)
 ```bash
 npm i @starknet-io/types-js@0.10.2
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ RPC 0.10.4 - **beta** (stable not yet released)
 
 | npm version | Spec |
 |---|---|
-| `npm i @starknet-io/types-js@0.10.4-beta.1` | rc0 - latest beta |
+| `npm i @starknet-io/types-js@0.10.4-beta.3` | rc2 - latest beta |
+| `npm i @starknet-io/types-js@0.10.4-beta.2` | rc1 |
+| `npm i @starknet-io/types-js@0.10.4-beta.1` | rc0 |
 
 RPC 0.10.3 - **latest**
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.4-beta.2",
+  "version": "0.10.4-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.4-beta.2",
+      "version": "0.10.4-beta.3",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.4-beta.1",
+  "version": "0.10.4-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.4-beta.1",
+      "version": "0.10.4-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3",
+  "version": "0.10.4-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.3",
+      "version": "0.10.4-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.4-beta.1",
+  "version": "0.10.4-beta.2",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.3",
+  "version": "0.10.4-beta.1",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-io/types-js",
-  "version": "0.10.4-beta.2",
+  "version": "0.10.4-beta.3",
   "author": "Toni Tabak <tabaktoni@gmail.com>",
   "repository": {
     "type": "git",

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -273,25 +273,6 @@ export const ETransactionVersion = {
 } as const
 
 export type ETransactionVersion = (typeof ETransactionVersion)[keyof typeof ETransactionVersion]
-/**
- * Old Transaction Versions
- */
-
-/**
- * @deprecated Starknet 0.14 will not support this transaction
- */
-export const ETransactionVersion2 = {
-  V0: ETransactionVersion.V0,
-  V1: ETransactionVersion.V1,
-  V2: ETransactionVersion.V2,
-  F0: ETransactionVersion.F0,
-  F1: ETransactionVersion.F1,
-  F2: ETransactionVersion.F2,
-} as const
-/**
- * @deprecated Starknet 0.14 will not support this transaction
- */
-export type ETransactionVersion2 = (typeof ETransactionVersion2)[keyof typeof ETransactionVersion2]
 
 /**
  * V3 Transaction Versions

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -114,7 +114,7 @@ export interface INSUFFICIENT_RESOURCES_FOR_VALIDATE {
 
 export interface INSUFFICIENT_ACCOUNT_BALANCE {
   code: 54
-  message: "Account balance is smaller than the transaction's max_fee"
+  message: "Account balance is smaller than the transaction's maximal fee (calculated as the sum of each resource's limit x max price)"
 }
 
 export interface VALIDATION_FAILURE {

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -254,17 +254,17 @@ export type STRK20_INVOKE_ACTION = {
 }
 
 /**
- * Identifies the dapp that scopes a set of STRK20 sub-accounts, as a single
+ * Identifies the dapp that scopes a set of STRK20 shadow accounts, as a single
  * felt. Either a 0x-prefixed felt, or a human-readable ASCII string of at most
  * 31 characters that the wallet encodes as a Cairo short string.
  */
 export type STRK20_DAPP_NAME = string
 
 /**
- * How much of the sub-account's token balance a settled open note collects.
- * 'all' collects the sub-account's entire token balance; 'diff' collects only
- * the balance gained during this interaction; 'exact' collects the given amount
- * (which must be provided).
+ * How much of the shadow account's token balance a settled open note
+ * collects. 'all' collects the shadow account's entire token balance; 'diff'
+ * collects only the balance gained during this interaction; 'exact' collects
+ * the given amount (which must be provided).
  */
 export type STRK20_COLLECT_POLICY =
   | { type: 'all' }
@@ -276,25 +276,25 @@ export type STRK20_COLLECT_POLICY =
     }
 
 /**
- * Invokes one or more contract calls through the user's STRK20 sub-account for a
- * dapp, routed via the sub-account anonymizer. The sub-account is selected by
- * (dapp_name, nonce); each nonce maps to a distinct, deterministic sub-account.
- * The proceeds of the calls are settled into the open notes created by transfer
- * actions with amount "OPEN" in the same transaction, so the usual rule applies:
- * the number of open notes filled by this action must match the number of open
- * notes created in the transaction.
+ * Invokes one or more contract calls through the user's STRK20 shadow account
+ * for a dapp, routed via the shadow account anonymizer. The shadow account is
+ * selected by (dapp_name, nonce); each nonce maps to a distinct, deterministic
+ * shadow account. The proceeds of the calls are settled into the open notes
+ * created by transfer actions with amount "OPEN" in the same transaction, so the
+ * usual rule applies: the number of open notes filled by this action must match
+ * the number of open notes created in the transaction.
  */
-export type STRK20_SUBACCOUNT_INVOKE_ACTION = {
-  type: 'subaccount_invoke'
-  /** The dapp that scopes the sub-account */
+export type STRK20_SHADOW_ACCOUNT_INVOKE_ACTION = {
+  type: 'shadow_account_invoke'
+  /** The dapp that scopes the shadow account */
   dapp_name: STRK20_DAPP_NAME
-  /** The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp */
+  /** The shadow account nonce; each nonce selects a distinct shadow account for this user + dapp */
   nonce: FELT
-  /** The contract calls to execute through the sub-account, in order (min 1). */
+  /** The contract calls to execute through the shadow account, in order (min 1). */
   calls: Call[]
   /**
    * A single policy applied to every open note this action settles: how much of
-   * the sub-account's balance each note collects.
+   * the shadow account's balance each note collects.
    */
   collect_policy: STRK20_COLLECT_POLICY
 }
@@ -308,7 +308,7 @@ export type STRK20_ACTION =
   | STRK20_WITHDRAW_ACTION
   | STRK20_TRANSFER_ACTION
   | STRK20_INVOKE_ACTION
-  | STRK20_SUBACCOUNT_INVOKE_ACTION
+  | STRK20_SHADOW_ACCOUNT_INVOKE_ACTION
 
 /**
  * A private balance for a single token held inside the privacy pool.

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -22,7 +22,7 @@ export type PADDED_FELT = string // TODO: STORAGE_KEY should also be PADDED_FELT
 /**
  * A Starknet JSON-RPC spec version, following semantic versioning.
  * @pattern ^[0-9]+\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z.-]+)?)?$
- * @example "0.10" | "0.10.3" | "0.10.3-rc.3"
+ * @example "0.10" | "0.10.4" | "0.10.4-rc.0"
  */
 export type SpecVersion =
   | `${number}.${number}`
@@ -155,7 +155,7 @@ export interface AccountDeploymentData {
  * A wallet API version, following semantic versioning (no pre-release).
  * When used as a request parameter and not specified, the latest is assumed.
  * @pattern ^[0-9]+\\.[0-9]+(\\.[0-9]+)?$
- * @example "0.8" | "0.10.3"
+ * @example "0.8" | "0.10.4"
  */
 export type API_VERSION = `${number}.${number}` | `${number}.${number}.${number}`
 
@@ -254,6 +254,52 @@ export type STRK20_INVOKE_ACTION = {
 }
 
 /**
+ * Identifies the dapp that scopes a set of STRK20 sub-accounts, as a single
+ * felt. Either a 0x-prefixed felt, or a human-readable ASCII string of at most
+ * 31 characters that the wallet encodes as a Cairo short string.
+ */
+export type STRK20_DAPP_NAME = string
+
+/**
+ * How much of the sub-account's token balance a settled open note collects.
+ * 'all' collects the sub-account's entire token balance; 'diff' collects only
+ * the balance gained during this interaction; 'exact' collects the given amount
+ * (which must be provided).
+ */
+export type STRK20_COLLECT_POLICY =
+  | { type: 'all' }
+  | { type: 'diff' }
+  | {
+      type: 'exact'
+      /** The exact amount to collect, in the token's smallest unit. */
+      amount: FELT
+    }
+
+/**
+ * Invokes one or more contract calls through the user's STRK20 sub-account for a
+ * dapp, routed via the sub-account anonymizer. The sub-account is selected by
+ * (dapp_name, nonce); each nonce maps to a distinct, deterministic sub-account.
+ * The proceeds of the calls are settled into the open notes created by transfer
+ * actions with amount "OPEN" in the same transaction, so the usual rule applies:
+ * the number of open notes filled by this action must match the number of open
+ * notes created in the transaction.
+ */
+export type STRK20_SUBACCOUNT_INVOKE_ACTION = {
+  type: 'subaccount_invoke'
+  /** The dapp that scopes the sub-account */
+  dapp_name: STRK20_DAPP_NAME
+  /** The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp */
+  nonce: FELT
+  /** The contract calls to execute through the sub-account, in order (min 1). */
+  calls: Call[]
+  /**
+   * A single policy applied to every open note this action settles: how much of
+   * the sub-account's balance each note collects.
+   */
+  collect_policy: STRK20_COLLECT_POLICY
+}
+
+/**
  * A single action to perform via the STRK20 privacy protocol. The `type` field
  * discriminates the variant.
  */
@@ -262,6 +308,7 @@ export type STRK20_ACTION =
   | STRK20_WITHDRAW_ACTION
   | STRK20_TRANSFER_ACTION
   | STRK20_INVOKE_ACTION
+  | STRK20_SUBACCOUNT_INVOKE_ACTION
 
 /**
  * A private balance for a single token held inside the privacy pool.

--- a/src/wallet-api/components.ts
+++ b/src/wallet-api/components.ts
@@ -69,7 +69,7 @@ export type Call = {
 }
 
 /**
- * INVOKE_TXN_V1
+ * INVOKE_TXN_V3
  * @see https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json
  */
 export interface AddInvokeTransactionParameters {

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -1,3 +1,4 @@
+import type { FELT } from '../api/components.js'
 import type { ChainId } from '../api/index.js'
 import type {
   AccountDeploymentData,
@@ -16,6 +17,7 @@ import type {
   STRK20_ACTION,
   STRK20_BALANCE_ENTRY,
   STRK20_CALL_AND_PROOF,
+  STRK20_DAPP_NAME,
   SwitchStarknetChainParameters,
   WatchAssetParameters,
 } from './components.js'
@@ -182,7 +184,9 @@ export interface RpcTypeToMessageMap {
    * or more STRK20 actions (deposit, withdraw, private transfer) as a single
    * atomic transaction. The wallet shows an approval UI and may take
    * significantly longer than wallet_addInvokeTransaction because SNIP-36 ZK proof
-   * generation is required; the dapp must tolerate long-running calls.
+   * generation is required; the dapp must tolerate long-running calls. The wallet
+   * adds the fee action itself: a withdraw action covering the paymaster/relayer
+   * fee required to submit, on top of the actions the dapp supplies.
    * Registration into the pool is transparent — if the user is not registered,
    * NOT_REGISTERED is returned.
    * @param params.actions An ordered list of STRK20 actions to execute atomically (min 1).
@@ -208,7 +212,9 @@ export interface RpcTypeToMessageMap {
    * Build the Starknet call (and SNIP-36 ZK proof) for a STRK20 transaction
    * without submitting it. The dapp submits the returned call itself. The wallet
    * supplies the viewing key and the user's private state (channels, notes); the
-   * dapp only describes the actions. When `simulate` is true the wallet skips the
+   * dapp only describes the actions. The wallet does not add a fee withdrawal
+   * action — the fee belongs to whoever submits, so the dapp covers it (for
+   * instance through its own paymaster). When `simulate` is true the wallet skips the
    * expensive, state-revealing proof generation and returns the call with an empty
    * proof — same shape, but NOT submittable on-chain (use for fee estimation / UI
    * previews). NOT_REGISTERED if the user is not registered.
@@ -248,6 +254,37 @@ export interface RpcTypeToMessageMap {
       api_version?: API_VERSION
     }
     result: STRK20_BALANCE_ENTRY[]
+    errors:
+      | Errors.NOT_REGISTERED
+      | Errors.INVALID_REQUEST_PAYLOAD
+      | Errors.USER_REFUSED_OP
+      | Errors.API_VERSION_NOT_SUPPORTED
+      | Errors.UNKNOWN_ERROR
+  }
+
+  /**
+   * Compute the commitment for a dapp's STRK20 sub-accounts. The commitment is
+   * computed locally by the wallet from the user's private state; no transaction
+   * is sent. When `nonce` is given, returns the full commitment for that single
+   * sub-account: hash(partial_commitment, nonce); each nonce maps to a distinct,
+   * deterministic sub-account for the user + dapp. When `nonce` is omitted,
+   * returns the partial (nonce-independent) commitment: hash(identity_key,
+   * dapp_name), where identity_key is derived from the user, their viewing key,
+   * and the sub-account anonymizer address. The partial commitment is shared by
+   * every sub-account the user derives for this dapp, so it can be published once
+   * to let a dapp recognize all of the user's sub-accounts without learning any
+   * individual nonce. NOT_REGISTERED if the user is not registered.
+   * @param params.dapp_name The dapp that scopes the sub-account(s).
+   * @param params.nonce The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp. When omitted, the partial commitment is returned instead.
+   * @returns The sub-account commitment: hash(partial_commitment, nonce) when `nonce` was given, otherwise the partial commitment hash(identity_key, dapp_name).
+   */
+  wallet_strk20SubaccountCommitment: {
+    params: {
+      dapp_name: STRK20_DAPP_NAME
+      nonce?: FELT
+      api_version?: API_VERSION
+    }
+    result: FELT
     errors:
       | Errors.NOT_REGISTERED
       | Errors.INVALID_REQUEST_PAYLOAD

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -263,22 +263,23 @@ export interface RpcTypeToMessageMap {
   }
 
   /**
-   * Compute the commitment for a dapp's STRK20 sub-accounts. The commitment is
-   * computed locally by the wallet from the user's private state; no transaction
-   * is sent. When `nonce` is given, returns the full commitment for that single
-   * sub-account: hash(partial_commitment, nonce); each nonce maps to a distinct,
-   * deterministic sub-account for the user + dapp. When `nonce` is omitted,
-   * returns the partial (nonce-independent) commitment: hash(identity_key,
-   * dapp_name), where identity_key is derived from the user, their viewing key,
-   * and the sub-account anonymizer address. The partial commitment is shared by
-   * every sub-account the user derives for this dapp, so it can be published once
-   * to let a dapp recognize all of the user's sub-accounts without learning any
-   * individual nonce. NOT_REGISTERED if the user is not registered.
-   * @param params.dapp_name The dapp that scopes the sub-account(s).
-   * @param params.nonce The sub-account nonce; each nonce selects a distinct sub-account for this user + dapp. When omitted, the partial commitment is returned instead.
-   * @returns The sub-account commitment: hash(partial_commitment, nonce) when `nonce` was given, otherwise the partial commitment hash(identity_key, dapp_name).
+   * Compute the commitment for a dapp's STRK20 shadow accounts. The commitment
+   * is computed locally by the wallet from the user's private state; no
+   * transaction is sent. When `nonce` is given, returns the full commitment for
+   * that single shadow account: hash(partial_commitment, nonce); each nonce maps
+   * to a distinct, deterministic shadow account for the user + dapp. When
+   * `nonce` is omitted, returns the partial (nonce-independent) commitment:
+   * hash(identity_key, dapp_name), where identity_key is derived from the user,
+   * their viewing key, and the shadow account anonymizer address. The partial
+   * commitment is shared by every shadow account the user derives for this dapp,
+   * so it can be published once to let a dapp recognize all of the user's shadow
+   * accounts without learning any individual nonce. NOT_REGISTERED if the user
+   * is not registered.
+   * @param params.dapp_name The dapp that scopes the shadow account(s).
+   * @param params.nonce The shadow account nonce; each nonce selects a distinct shadow account for this user + dapp. When omitted, the partial commitment is returned instead.
+   * @returns The shadow account commitment: hash(partial_commitment, nonce) when `nonce` was given, otherwise the partial commitment hash(identity_key, dapp_name).
    */
-  wallet_strk20SubaccountCommitment: {
+  wallet_strk20ShadowAccountCommitment: {
     params: {
       dapp_name: STRK20_DAPP_NAME
       nonce?: FELT

--- a/src/wallet-api/methods.ts
+++ b/src/wallet-api/methods.ts
@@ -245,12 +245,15 @@ export interface RpcTypeToMessageMap {
    * token address; an empty array returns balances of all shielded tokens the
    * wallet holds. NOT_REGISTERED if the user is not registered.
    * @param params.tokens Token addresses to query; an empty array returns all shielded tokens.
+   * @param params.valid_until Expiry of the balance-read authorization, as a Unix timestamp in seconds; if omitted, the wallet applies its own default window.
    * @returns Balance per token.
    */
   wallet_strk20Balances: {
     params: {
       /** Token addresses to query. Pass an empty array to return balances of all shielded tokens in the privacy pool. */
       tokens: Address[]
+      /** Requested expiry of the balance-read authorization, as a Unix timestamp in seconds. When omitted, the wallet applies its own default window. */
+      valid_until?: number
       api_version?: API_VERSION
     }
     result: STRK20_BALANCE_ENTRY[]


### PR DESCRIPTION
## Promote beta → main: RPC 0.10.4 (stable release)

Promotes `beta` to `main` to trigger the stable `0.10.4` release
(semantic-release, patch bump from `0.10.3`).

Spec [`v0.10.4`](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.4) is
final: compared against `v0.10.4-rc.2` through the GitHub compare API, the only differences
are the `"version"` strings across the 11 spec/package files — no semantic change. The types
shipped in `0.10.4-beta.3` therefore already match the final spec.

### Included

- **STRK20 shadow accounts** (wallet API) — `STRK20_DAPP_NAME`, `STRK20_COLLECT_POLICY` and
  `STRK20_SHADOW_ACCOUNT_INVOKE_ACTION` (added to the `STRK20_ACTION` union), plus the
  `wallet_strk20ShadowAccountCommitment` method. These landed under the *sub-account* name in
  `beta.1` and were renamed in `beta.2` per
  [starknet-specs PR #406](https://github.com/starkware-libs/starknet-specs/pull/406), so only
  the final shadow-account naming ever reaches `main`.
- **`wallet_strk20Balances`** — new optional `valid_until` param: Unix timestamp expiry of the
  balance-read authorization; the wallet applies its own default window when omitted.
- **Fee responsibility** documented on `wallet_strk20InvokeTransaction` vs
  `wallet_strk20PrepareInvoke` (the submitter pays).
- **v1 transaction leftovers cleaned up** — `ETransactionVersion2` dropped,
  `INSUFFICIENT_ACCOUNT_BALANCE` message realigned on the spec wording, stale `INVOKE_TXN_V1`
  JSDoc corrected to `INVOKE_TXN_V3`. Spec-mandated v1 *read* types are kept.
- **README** — RPC 0.10.4 marked **latest / stable**; wallet-api spec link and logo image
  unpinned from fixed commits.

### Note for consumers

Although this ships as a patch (per this repo's convention of using `fix:` for spec
implementation work, to keep the package version aligned with the RPC spec version), two
changes are source-visible for TypeScript consumers upgrading from `0.10.3`:
`ETransactionVersion2` is removed (it was already `@deprecated` and non-spec), and the
`INSUFFICIENT_ACCOUNT_BALANCE.message` literal type changed.

### Validation

- Commit-type audit of `main..beta`: 4 × `fix:`, 3 × `chore(release):`, 1 × `chore:`,
  1 × `docs:` — no `feat:`, no `BREAKING CHANGE` footer → resolves to a **patch** bump from
  `0.10.3`, i.e. **`0.10.4`**.
- `npm run ts:check` — passes.
